### PR TITLE
Bump dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,13 +28,13 @@
     <properties>
       <apache.common.text>1.8</apache.common.text>
       <awaitility.version>3.1.6</awaitility.version>
-      <cdap.version>6.1.1</cdap.version>
+      <cdap.version>6.8.0</cdap.version>
       <common.logging.version>1.2</common.logging.version>
       <gson.version>2.2.4</gson.version>
-      <hadoop.version>2.8.0</hadoop.version>
+      <hadoop.version>2.10.2</hadoop.version>
       <http.client>4.5.10</http.client>
       <http.core>4.4.4</http.core>
-      <hydrator.version>2.3.0-SNAPSHOT</hydrator.version>
+      <hydrator.version>2.10.0</hydrator.version>
       <junit.version>4.11</junit.version>
       <mockito.version>1.10.19</mockito.version>
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -53,10 +53,6 @@
     </issueManagement>
 
     <repositories>
-       <repository>
-         <id>maven2</id>
-         <url>http://repo1.maven.org/maven2</url>
-       </repository>
         <repository>
             <id>sonatype</id>
             <url>https://oss.sonatype.org/content/groups/public</url>
@@ -435,8 +431,8 @@
                 <version>1.1.0</version>
                 <configuration>
                     <cdapArtifacts>
-                        <parent>system:cdap-data-pipeline[6.1.1,7.0.0-SNAPSHOT)</parent>
-                        <parent>system:cdap-data-streams[6.1.1,7.0.0-SNAPSHOT)</parent>
+                        <parent>system:cdap-data-pipeline[6.8.0,7.0.0-SNAPSHOT)</parent>
+                        <parent>system:cdap-data-streams[6.8.0,7.0.0-SNAPSHOT)</parent>
                     </cdapArtifacts>
                 </configuration>
                 <executions>


### PR DESCRIPTION
Bumped dependencies:
 - CDAP -> 6.8.0
 - Hydrator Plugins -> 2.10.0
 - Hadoop -> 2.10.2

Tested:
 - Unit Tests Passed
 - io.cdap.plugin.zuora.etl.ZuoraRealtimeSourceTest fails due to requiring Zuora credentials.